### PR TITLE
default export should be the last

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "types": "dist/index.d.ts",
   "module": "dist/sassy-datepicker.esm.js",
   "exports": {
-    "default": "./dist/index.js",
     "require": "./dist/sassy-datepicker.cjs.production.min.js",
-    "import": "./dist/sassy-datepicker.esm.js"
+    "import": "./dist/sassy-datepicker.esm.js",
+    "default": "./dist/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Webpack (5.58.2) doesn't like the order of the exports in package.json: `Module not found: Error: Default condition should be last one`

Similar issue to here: https://issueexplorer.com/issue/spencermountain/compromise/815
