### PR TITLE
feat: Add support for display 12 hour time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,15 +248,24 @@ Note - You will have to use the `!important` directive to override the default s
 #### Props
 
 | Name      |          Type           | Description                                                                   |
-| :-------- | :---------------------: | :---------------------------------------------------------------------------- |
+| :-------- |:-----------------------:|:------------------------------------------------------------------------------|
 | onChange  | `(date: Time) => void;` | This function is triggered every time the selected time in the picker changes |
 | value     |         `Time`          | The selected date                                                             |
+| options   |   `TimePickerOptions`   | Some configuration options for the TimePicker                                 |
 | minTime   |         `Time`          | The lowest date value allowed                                                 |
 | maxTime   |         `Time`          | The highest date value allowed                                                |
 | className |        `string`         | The className prop                                                            |
 | ref       |   `React.ForwardRef`    | The ref prop                                                                  |
 
 And all the other react props for an `HTMLDivElement`.
+
+Type definition for `TimePickerOptions`
+
+```ts
+type TimePickerOptions = {
+  displayFormat: '12hr' | '24hr'; # default 24hr
+};
+```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Type definition for `TimePickerOptions`
 
 ```ts
 type TimePickerOptions = {
-  displayFormat: '12hr' | '24hr'; # default 24hr
+  displayFormat: '12hr' | '24hr'; // default 24hr
 };
 ```
 

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CustomSelect, { OptionType } from '../components/select';
-import { TimePickerOptions } from './types';
+import { Meridiem, TimePickerOptions } from './types';
 
 import './styles.css';
 import { convertHourFrom12Hrto24Hr } from '../util';
@@ -19,7 +19,7 @@ export type Time = {
 export type TimeDisplay = {
   hours: number;
   minutes: number;
-  amPm?: 'AM' | 'PM'
+  meridiem?: Meridiem;
 }
 
 /**
@@ -98,17 +98,17 @@ const isMinuteOptionDisabled = (
  */
 const to12HrTimeDisplay = (selectedTime: Time): TimeDisplay => {
   let hours;
-  let amPm: any = 'AM';
+  let meridiem = Meridiem.AM;
   if (selectedTime.hours === 0) {
     hours = 12;
   }
   else if (selectedTime.hours === 12) {
     hours = 12;
-    amPm = 'PM';
+    meridiem = Meridiem.PM;
   }
   else if (selectedTime.hours > 12) {
     hours = selectedTime.hours - 12
-    amPm = 'PM';
+    meridiem = Meridiem.PM;
   }
   else {
     hours = selectedTime.hours
@@ -117,7 +117,7 @@ const to12HrTimeDisplay = (selectedTime: Time): TimeDisplay => {
   return {
     hours,
     minutes: selectedTime.minutes,
-    amPm
+    meridiem
   };
 };
 
@@ -197,8 +197,8 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
       (v: string) => {
         setSelectedTime((t) => {
           let h = Number(v);
-          if (options.displayFormat === '12hr' && displayTime.amPm) {
-            h = convertHourFrom12Hrto24Hr(h, displayTime.amPm);
+          if (options.displayFormat === '12hr' && displayTime.meridiem) {
+            h = convertHourFrom12Hrto24Hr(h, displayTime.meridiem);
           }
 
           if (h === minTime.hours && t.minutes < minTime.minutes) {
@@ -217,15 +217,15 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
           }
         });
       },
-      [minutesInterval, maxTime, minTime, displayTime.amPm]
+      [minutesInterval, maxTime, minTime, displayTime.meridiem]
     );
 
-    const handleAmPmChange = React.useCallback(
+    const handleMeridiemChange = React.useCallback(
       (v: string) => {
         setSelectedTime((t) => {
           let h;
 
-          if (v === 'AM') {
+          if (v === Meridiem.AM) {
             // when switching to PM make 12 hour 0
             h = t.hours === 12 ? 0 : t.hours - 12;
           }
@@ -261,8 +261,8 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
       let normalizedHour;
       for (let i = startIndex; i <= maxHours; i++) {
         normalizedHour = i;
-        if (options.displayFormat === '12hr' && displayTime.amPm) {
-          normalizedHour = convertHourFrom12Hrto24Hr(i, displayTime.amPm)
+        if (options.displayFormat === '12hr' && displayTime.meridiem) {
+          normalizedHour = convertHourFrom12Hrto24Hr(i, displayTime.meridiem)
         }
 
         o.push({
@@ -271,9 +271,9 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
         });
       }
       return o;
-    }, [maxTime, minTime, options.displayFormat, displayTime.amPm]);
+    }, [maxTime, minTime, options.displayFormat, displayTime.meridiem]);
 
-    const amPmOptions = React.useMemo<OptionType<string>[]>(() => {
+    const meridiemOptions = React.useMemo<OptionType<string>[]>(() => {
       let isPmDisabled = false;
       let isAmDisabled = false;
 
@@ -335,11 +335,11 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
           onChange={handleMinutesChange}
           options={minuteOptions}
         />
-        { displayTime.amPm &&
+        { displayTime.meridiem &&
           <CustomSelect
-            value={displayTime.amPm}
-            onChange={handleAmPmChange}
-            options={amPmOptions}
+            value={displayTime.meridiem}
+            onChange={handleMeridiemChange}
+            options={meridiemOptions}
           />
         }
       </div>

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import CustomSelect, { OptionType } from '../components/select';
+import { TimePickerOptions } from './types';
 
 import './styles.css';
+import { convertHourFrom12Hrto24Hr } from '../util';
 
 /**
  * Time type
@@ -10,6 +12,15 @@ export type Time = {
   hours: number;
   minutes: number;
 };
+
+/**
+ * Time display type
+ */
+export type TimeDisplay = {
+  hours: number;
+  minutes: number;
+  amPm?: 'AM' | 'PM'
+}
 
 /**
  * Props for TimePicker React Component
@@ -35,9 +46,17 @@ export type TimePickerProps = {
    * The number of minutes between each minute select option - default is 30
    */
   minutesInterval?: number;
+  /**
+   * TimePicker configuration options
+   */
+  options?: TimePickerOptions;
 } & React.PropsWithRef<
-  Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'selected' | 'value'>
+  Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'selected' | 'options' | 'value'>
 >;
+
+const defaultOptions: TimePickerOptions = {
+  displayFormat: '24hr'
+}
 
 /**
  *
@@ -73,6 +92,36 @@ const isMinuteOptionDisabled = (
   (selectedTime.hours === maxTime.hours && i > maxTime.minutes) ||
   (selectedTime.hours === minTime.hours && i < minTime.minutes);
 
+/**
+ * Convert Time to a 12hr TimeDisplay format
+ * @param selectedTime
+ */
+const to12HrTimeDisplay = (selectedTime: Time): TimeDisplay => {
+  let hours;
+  let amPm: any = 'AM';
+  if (selectedTime.hours === 0) {
+    hours = 12;
+  }
+  else if (selectedTime.hours === 12) {
+    hours = 12;
+    amPm = 'PM';
+  }
+  else if (selectedTime.hours > 12) {
+    hours = selectedTime.hours - 12
+    amPm = 'PM';
+  }
+  else {
+    hours = selectedTime.hours
+  }
+
+  return {
+    hours,
+    minutes: selectedTime.minutes,
+    amPm
+  };
+};
+
+
 // sane defaults
 const MIN_TIME = { hours: 0, minutes: 0 };
 const MAX_TIME = { hours: 23, minutes: 59 };
@@ -89,6 +138,7 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
       minTime = MIN_TIME,
       maxTime = MAX_TIME,
       minutesInterval = MINUTES_INTERVAL,
+      options = defaultOptions,
       className,
       ...props
     },
@@ -112,6 +162,14 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
         minutesInterval
       );
     });
+
+    const [displayTime, setDisplayTime] = React.useState(() => {
+      if (options.displayFormat === '12hr') {
+        return to12HrTimeDisplay(selectedTime);
+      }
+
+      return {...selectedTime};
+    })
 
     const handleMinutesChange = React.useCallback(
       (v: string) => {
@@ -138,7 +196,11 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
     const handleHoursChange = React.useCallback(
       (v: string) => {
         setSelectedTime((t) => {
-          const h = Number(v);
+          let h = Number(v);
+          if (options.displayFormat === '12hr' && displayTime.amPm) {
+            h = convertHourFrom12Hrto24Hr(h, displayTime.amPm);
+          }
+
           if (h === minTime.hours && t.minutes < minTime.minutes) {
             return alignTime(
               { hours: h, minutes: minTime.minutes },
@@ -155,7 +217,27 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
           }
         });
       },
-      [minutesInterval, maxTime, minTime]
+      [minutesInterval, maxTime, minTime, displayTime.amPm]
+    );
+
+    const handleAmPmChange = React.useCallback(
+      (v: string) => {
+        setSelectedTime((t) => {
+          let h;
+
+          if (v === 'AM') {
+            // when switching to PM make 12 hour 0
+            h = t.hours === 12 ? 0 : t.hours - 12;
+          }
+          else {
+            // when switching to PM make 0 hour 12
+            h = t.hours === 0 ? 12 : t.hours + 12;
+          }
+
+          return alignTime({...t, hours: h}, minutesInterval)
+        })
+      },
+      [maxTime, minTime]
     );
 
     // the array of options for the minutes to select from
@@ -172,15 +254,56 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
     }, [minutesInterval, maxTime, minTime, selectedTime.hours]);
 
     const hourOptions = React.useMemo<OptionType<string>[]>(() => {
-      let options: OptionType<string>[] = [];
-      for (let i = 0; i <= 23; i++) {
-        options.push({
+      const [startIndex, maxHours] = options.displayFormat === '12hr' ?
+        [1, 12] : [0, 23];
+
+      let o: OptionType<string>[] = [];
+      let normalizedHour;
+      for (let i = startIndex; i <= maxHours; i++) {
+        normalizedHour = i;
+        if (options.displayFormat === '12hr' && displayTime.amPm) {
+          normalizedHour = convertHourFrom12Hrto24Hr(i, displayTime.amPm)
+        }
+
+        o.push({
           value: [i.toString(), i.toString().padStart(2, '0')],
-          disabled: minTime.hours > i || maxTime.hours < i,
+          disabled: minTime.hours > normalizedHour || maxTime.hours < normalizedHour,
         });
       }
-      return options;
-    }, [maxTime, minTime]);
+      return o;
+    }, [maxTime, minTime, options.displayFormat, displayTime.amPm]);
+
+    const amPmOptions = React.useMemo<OptionType<string>[]>(() => {
+      let isPmDisabled = false;
+      let isAmDisabled = false;
+
+      if (minTime.hours > 11) {
+        isAmDisabled = true
+      }
+      else if (selectedTime.hours > 11) {
+        const h = selectedTime.hours - 12;
+        if (h < minTime.hours || h === minTime.hours && selectedTime.minutes < minTime.minutes) {
+          isAmDisabled = true;
+        }
+      }
+
+      if (maxTime.hours < 12) {
+        isPmDisabled = true
+      }
+      else if (selectedTime.hours < 12) {
+        const h = selectedTime.hours + 12;
+        if (h > maxTime.hours || h === maxTime.hours && selectedTime.minutes > maxTime.minutes) {
+          isPmDisabled = true;
+        }
+      }
+
+      return [
+        // {value: ['AM', 'AM'], disabled: minTime.hours > 11 },
+        {value: ['AM', 'AM'], disabled: isAmDisabled },
+        {value: ['PM', 'PM'], disabled: isPmDisabled }
+        // {value: ['PM', 'PM'], disabled: maxTime.hours < 12 || (selectedTime.hours > maxTime.hours) }
+      ]
+    }, [maxTime, minTime, selectedTime.hours, selectedTime.minutes]);
 
     React.useEffect(() => {
       onChange?.(selectedTime);
@@ -193,19 +316,34 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [minutesInterval]);
 
+    React.useEffect(() => {
+      let displayTime = selectedTime;
+      if (options.displayFormat === '12hr') {
+        displayTime = to12HrTimeDisplay(selectedTime);
+      }
+      setDisplayTime(displayTime);
+    }, [selectedTime, options.displayFormat])
+
     return (
       <div className={`stp ${className ?? ''}`} {...props} ref={ref}>
         <CustomSelect
-          value={selectedTime.hours.toString().padStart(2, '0')}
+          value={displayTime.hours.toString().padStart(2, '0')}
           onChange={handleHoursChange}
           options={hourOptions}
         />
         <p>:</p>
         <CustomSelect
-          value={selectedTime.minutes.toString().padStart(2, '0')}
+          value={displayTime.minutes.toString().padStart(2, '0')}
           onChange={handleMinutesChange}
           options={minuteOptions}
         />
+        { displayTime.amPm &&
+          <CustomSelect
+            value={displayTime.amPm}
+            onChange={handleAmPmChange}
+            options={amPmOptions}
+          />
+        }
       </div>
     );
   }

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -298,10 +298,8 @@ const TimePicker = React.forwardRef<HTMLDivElement, TimePickerProps>(
       }
 
       return [
-        // {value: ['AM', 'AM'], disabled: minTime.hours > 11 },
         {value: ['AM', 'AM'], disabled: isAmDisabled },
         {value: ['PM', 'PM'], disabled: isPmDisabled }
-        // {value: ['PM', 'PM'], disabled: maxTime.hours < 12 || (selectedTime.hours > maxTime.hours) }
       ]
     }, [maxTime, minTime, selectedTime.hours, selectedTime.minutes]);
 

--- a/src/time-picker/types.ts
+++ b/src/time-picker/types.ts
@@ -1,0 +1,6 @@
+export type TimePickerOptions = {
+  /**
+   * Which time format to use
+   */
+  displayFormat: '12hr' | '24hr';
+};

--- a/src/time-picker/types.ts
+++ b/src/time-picker/types.ts
@@ -4,3 +4,8 @@ export type TimePickerOptions = {
    */
   displayFormat: '12hr' | '24hr';
 };
+
+export enum Meridiem {
+  AM = 'AM',
+  PM = 'PM',
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -182,3 +182,21 @@ export const getDatesOfMonth = (date: Date, minDateValue: number, maxDateValue: 
 
   return dates;
 };
+
+/**
+ * Convert a 12hr time to 24 hour.
+ *
+ * @param hour hour to convert
+ * @param amPm am or pm
+ */
+export const convertHourFrom12Hrto24Hr = (hour: number, amPm: 'AM' | 'PM'): number  => {
+  if (hour === 12) {
+     return amPm === 'AM' ? 0 : 12;
+  }
+  else if (amPm === 'PM') {
+    return hour + 12;
+  }
+  else {
+    return hour
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import dt from 'date-and-time';
-import type { WeekStartDay, DisplayDate } from './date-picker/types';
+import type { DisplayDate, WeekStartDay } from './date-picker/types';
+import { Meridiem } from './time-picker/types';
 
 enum DAYS {
   'Sunday' = 0,
@@ -187,13 +188,13 @@ export const getDatesOfMonth = (date: Date, minDateValue: number, maxDateValue: 
  * Convert a 12hr time to 24 hour.
  *
  * @param hour hour to convert
- * @param amPm am or pm
+ * @param meridiem am or pm
  */
-export const convertHourFrom12Hrto24Hr = (hour: number, amPm: 'AM' | 'PM'): number  => {
+export const convertHourFrom12Hrto24Hr = (hour: number, meridiem: Meridiem): number  => {
   if (hour === 12) {
-     return amPm === 'AM' ? 0 : 12;
+     return meridiem === Meridiem.AM ? 0 : 12;
   }
-  else if (amPm === 'PM') {
+  else if (meridiem === Meridiem.PM) {
     return hour + 12;
   }
   else {


### PR DESCRIPTION
This PR adds support for displaying the `TimePicker` component in 12-hr format (i.e. 10:00 am)

**Sample Usage**
```
 <TimePicker className="time-picker" minutesInterval={5} options={{displayFormat: '12hr'}} />
```
The default behavior stays the same and will show the 24 hour style if nothing is defined.

**Visual Design**
<img width="141" alt="Screen Shot 2022-08-26 at 2 48 29 PM" src="https://user-images.githubusercontent.com/374289/187005424-b418adf0-c929-499f-b260-acc664e9ea1c.png">

<img width="146" alt="Screen Shot 2022-08-26 at 3 24 53 PM" src="https://user-images.githubusercontent.com/374289/187005440-e7d58310-bf15-4880-b289-75b0c8920727.png">


**Implementation Notes**
For the implementation I opted to include a new `TimeDisplay` type which has `hours`, `minutes`, `amPm (optional)`.  This is used to determine if we show only hours, minutes or hours, minutes and the am/pm selector.  The actual component value will remain in 24 hour time format.  The PR is mostly an exercise in transforming the selected time into the correct TimeDisplay based on the options used for the TimePicker.

The minTime and maxTime is functional as well. When a control is changed it will enabled/disable options based on the max/min time constraints.

Please let me know if you have any questions or need any changes, in order to accept this! 👍 